### PR TITLE
Fix right side gap

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,7 @@
 body {
 	align-items: stretch;
 	display: grid;
-	grid-template-columns: 150px 150px 19% 19% 19% 19%;
+	grid-template-columns: 10% 10% 1fr 1fr 1fr 1fr;
 	grid-template-rows: 200px 200px 190px 190px 190px;
 	grid-template-areas: 
 		"aside aside main main main main"


### PR DESCRIPTION
Changes grid-template-column to use % and fr. Deprecation warning is coming from grid-template-row, so we will have to look into resizing the height of the rows using % or fr without messing up the comp.